### PR TITLE
Fix: Add support for 'neg' unary operator in SymPy backend

### DIFF
--- a/cyecca/backends/sympy.py
+++ b/cyecca/backends/sympy.py
@@ -327,7 +327,7 @@ class SympyBackend(Backend):
         elif isinstance(expr, UnaryOp):
             operand = self._convert_expr(expr.operand)
 
-            if expr.op == "-":
+            if expr.op == "-" or expr.op == "neg":
                 return -operand
             elif expr.op == "+":
                 return operand


### PR DESCRIPTION
The SymPy backend was failing when encountering the 'neg' unary operator in expressions generated by Rumoca. Previously, only the '-' operator was handled, but Rumoca sometimes generates 'neg' as the unary negation operator.

This fix adds support for both '-' and 'neg' operators in the UnaryOp handler, allowing models like MassSpringPD to compile successfully.

Error before fix:
ValueError: Unsupported unary operator: neg

🤖 Generated with [Claude Code](https://claude.com/claude-code)